### PR TITLE
Workaround to fix call_user() on A2560U

### DIFF
--- a/src/m68k/startup_m68k.s
+++ b/src/m68k/startup_m68k.s
@@ -380,7 +380,7 @@ _call_user:
             move.l (8,a7),a1            ; Get the pointer to the process's stack
             move.l (12,a7),d0           ; Get the number of parameters passed
             move.l (16,a7),a2           ; Get the pointer to the parameters
-            andi #$dfff,sr              ; Drop into user mode
+            ; andi #$dfff,sr              ; Drop into user mode
             movea.l a1,a7               ; Set the stack
 
             move.l a2,-(a7)             ; Push the parameters list


### PR DESCRIPTION
# Changes
- Had to comment out Change to Usermode in `call_user` function to fix loaders.
- For some reason user_call was hanging on `andi #dfff,sr` call
- This is a workaround until we have a better solution.