### PR TITLE
Ignore python precompiled bytecode cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+# Python cache
+C256Mgr/__pycache__/
+
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
When using python3 on linux, I got these generated. This is only cache and has no reason to be included in the repo so I excluded this cache in the .gitignore.