### PR TITLE
Added CWD to Prompt

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -259,6 +259,7 @@ short cli_rerepl() {
 //
 short cli_repl(short channel) {
     char command_line[MAX_COMMAND_SIZE];
+    char cwd_buffer[MAX_PATH_LEN];
     char * arg;
     char * token_save;
     char * delim = " ";
@@ -268,7 +269,11 @@ short cli_repl(short channel) {
     g_current_channel = channel;
 
     while (1) {
-        sys_chan_write(channel, "\n> ", 3);                           // Print our prompt
+        sys_chan_write(channel, "\n", 1);
+        if(sys_fsys_get_cwd(cwd_buffer, MAX_PATH_LEN) == 0) {
+            sys_chan_write(channel, cwd_buffer, strlen(cwd_buffer));
+        }
+        sys_chan_write(channel, "> ", 2);                           // Print our prompt
         sys_chan_readline(channel, command_line, MAX_COMMAND_SIZE);   // Attempt to read line
         sys_chan_write(channel, "\n", 1);
 

--- a/src/dev/fsys.c
+++ b/src/dev/fsys.c
@@ -456,7 +456,6 @@ short fsys_set_cwd(const char * path) {
 short fsys_get_cwd(char * path, short size) {
     FRESULT result;
 
-    f_chdrive("");
     result = f_getcwd(path);
     if (result == FR_OK) {
         return 0;


### PR DESCRIPTION
# Changes
- Fixed bug in `fsys_get_cwd`, where the function called `f_chdrive("");`
- Added the current working directory to the prompt