### PR TITLE
Add missing codec wait

### DIFF
--- a/src/snd/codec.c
+++ b/src/snd/codec.c
@@ -42,8 +42,9 @@ void codec_set_volume(unsigned char vol) {
     volume = vol;
 
     *CODEC = 0x0A00 | (0xFF - (vol & 0xFF));
-    *CODEC = 0x0400 | ((vol >> 1) & 0xff);
+    codec_wait();
 
+	*CODEC = 0x0400 | ((vol >> 1) & 0xff);
     codec_wait();
 }
 


### PR DESCRIPTION
There should be a codec_wait after command sent to the CODEC. One was missing.