### PR TITLE
Fix memory corruption in test

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -7,9 +7,9 @@
 
 /*
  * A function pointer for command implementations:
- *  int cmd_foo(short screen, char * parameters) { ... }
+ *  short cmd_foo(short screen, char * parameters) { ... }
  */
-typedef int (*cli_cmd_handler)(short screen, int argc, char * argv[]);
+typedef short (*cli_cmd_handler)(short screen, int argc, char * argv[]);
 
 /**
  * About the CLI...

--- a/src/cli/test_cmd2.c
+++ b/src/cli/test_cmd2.c
@@ -324,7 +324,7 @@ short cmd_test_print(short screen, int argc, char * argv[]) {
     return 0;
 }
 
-static t_cli_test_feature cli_test_features[] = {
+const t_cli_test_feature cli_test_features[] = {
     {"BITMAP", "BITMAP: test the bitmap screen", cli_test_bitmap},
     {"CREATE", "CREATE <path>: test creating a file", cli_test_create},
     {"IDE", "IDE: test reading the MBR of the IDE drive", cli_test_ide},
@@ -339,7 +339,7 @@ static t_cli_test_feature cli_test_features[] = {
     {"PSG", "PSG: test the PSG sound chip", psg_test},
     {"PRINT", "PRINT: sent text to the printer", cmd_test_print},
     {"UART", "UART: test the serial port", cli_test_uart},
-    {0, 0}
+    {0, 0, 0}
 };
 
 void test_help(short screen) {

--- a/src/m68k/startup_m68k.s
+++ b/src/m68k/startup_m68k.s
@@ -125,11 +125,10 @@ coldboot:   lea ___STACK,sp
             ; Clear BSS segment
             lea	   ___BSSSTART,a0            
             move.l #___BSSSIZE,d0
-            add.l  a0,d0
             beq.s  callmain
 
 clrloop:    clr.l  (a0)+
-            cmpa.l d0,a0
+            subq.l #4,d0
             bne.s  clrloop
 
             ; Set TRAP #15 vector handler

--- a/src/m68k/startup_m68k.s
+++ b/src/m68k/startup_m68k.s
@@ -127,7 +127,11 @@ coldboot:   lea ___STACK,sp
             move.l #___BSSSIZE,d0
             beq.s  callmain
 
-clrloop:    clr.l  (a0)+
+clrloop:    ; We don't use clr.l because it's a read-modify-write operation
+            ; that is not yet supported by the FPGA's bus logic for now.
+            ; So we use a move instead.
+            ; clr.l  (a0)+
+            move.l #0,(a0)+
             subq.l #4,d0
             bne.s  clrloop
 

--- a/src/m68k/startup_m68k.s
+++ b/src/m68k/startup_m68k.s
@@ -122,13 +122,15 @@ PENDING_GRP2 = $00B00104
 coldboot:   lea ___STACK,sp
             bsr _int_disable_all
 
-            lea	___BSSSTART,a0
+            ; Clear BSS segment
+            lea	   ___BSSSTART,a0            
             move.l #___BSSSIZE,d0
-            beq	callmain
+            add.l  a0,d0
+            beq.s  callmain
 
-            ; clrloop:    clr.l (a0)+
-            ; subq.l #4,d0
-            ; bne	clrloop
+clrloop:    clr.l  (a0)+
+            cmpa.l d0,a0
+            bne.s  clrloop
 
             ; Set TRAP #15 vector handler
             lea h_trap_15,a0        ; Address of the handler


### PR DESCRIPTION
The code clearing the BSS segment in the startup code was disabled. I think some variables where therefore not having the expected value upon startup.
1 Reinstated the BSS clearing code.
2 Improved declaration according to PJW's findings.
3 Updated the type for  CLI command handlers to be a function returning `short` rather than `int` since it's really what the existing handlers do. This removes some warnings about incompatible pointer type.