### PR TITLE
Remove warnings 1

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -9,7 +9,7 @@
  * A function pointer for command implementations:
  *  short cmd_foo(short screen, char * parameters) { ... }
  */
-typedef short (*cli_cmd_handler)(short screen, int argc, char * argv[]);
+typedef short (*cli_cmd_handler)(short screen, int argc, const char * argv[]);
 
 /**
  * About the CLI...
@@ -42,6 +42,6 @@ extern long cli_eval_number(const char * arg);
 /*
  * Print a help message
  */
-extern int cmd_help(short channel, int argc, char * argv[]);
+extern short cmd_help(short channel, int argc, const char * argv[]);
 
 #endif

--- a/src/cli/dis68k.c
+++ b/src/cli/dis68k.c
@@ -124,23 +124,23 @@ static void sprintmode(unsigned int mode, unsigned int reg, unsigned int size, c
 	const char ir[2] = {'W','L'}; /* for mode 6 */
 
 	switch(mode) {
-		case 0  : sprintf(out_s, "D%i", reg);		break;
-		case 1  : sprintf(out_s, "A%i", reg);		break;
-		case 2  : sprintf(out_s, "(A%i)", reg);		break;
-		case 3  : sprintf(out_s, "(A%i)+", reg);	break;
-		case 4  : sprintf(out_s, "-(A%i)", reg);	break;
+		case 0  : sprintf(out_s, "D%u", reg);		break;
+		case 1  : sprintf(out_s, "A%u", reg);		break;
+		case 2  : sprintf(out_s, "(A%u)", reg);		break;
+		case 3  : sprintf(out_s, "(A%u)+", reg);	break;
+		case 4  : sprintf(out_s, "-(A%u)", reg);	break;
 		case 5  : /* reg + disp */
 		case 9  : { /* pcr + disp */
 			int32_t displacement = (int32_t) getword();
 			if (displacement >= 32768) displacement -= 65536;
 			if (mode == 5) {
-				sprintf(out_s, "%+i(A%i)", displacement, reg);
+				sprintf(out_s, "%+li(A%u)", displacement, reg);
 			} else {
 				const uint32_t ldata = address - 2 + displacement;
 				if (!rawmode) {
-					sprintf(out_s, "%+i(PC) {$%08u}", displacement, ldata);
+					sprintf(out_s, "%+li(PC) {$%08lu}", displacement, ldata);
 				} else {
-					sprintf(out_s, "%+i(PC)", displacement);
+					sprintf(out_s, "%+li(PC)", displacement);
 				}
 			}
 		} break;
@@ -157,15 +157,15 @@ static void sprintmode(unsigned int mode, unsigned int reg, unsigned int size, c
 
 			if (mode == 6) {
 				if (itype == 0) {
-					sprintf(out_s, "%+i(A%i,D%i.%c)", displacement, reg, ireg, ir[isize]);
+					sprintf(out_s, "%+d(A%u,D%d.%c)", displacement, reg, ireg, ir[isize]);
 				} else {
-					sprintf(out_s, "%+i(A%i,A%i.%c)", displacement, reg, ireg, ir[isize]);
+					sprintf(out_s, "%+d(A%u,A%d.%c)", displacement, reg, ireg, ir[isize]);
 				}
 			} else { /* PC */
 				if (itype == 0) {
-					sprintf(out_s, "%+i(PC,D%i.%c)", displacement, ireg, ir[isize]);
+					sprintf(out_s, "%+d(PC,D%d.%c)", displacement, ireg, ir[isize]);
 				} else {
-					sprintf(out_s, "%+i(PC,A%i.%c)", displacement, ireg, ir[isize]);
+					sprintf(out_s, "%+d(PC,A%d.%c)", displacement, ireg, ir[isize]);
 				}
 			}
 		} break;
@@ -191,7 +191,7 @@ static void sprintmode(unsigned int mode, unsigned int reg, unsigned int size, c
 			}
 		} break;
 		default : {
-			sprintf(line_buf, "Mode out of range in sprintmode = %i\n", mode);
+			sprintf(line_buf, "Mode out of range in sprintmode = %u\n", mode);
 			print(0,line_buf);
 			break;
 		}
@@ -224,7 +224,7 @@ void disasm(unsigned long int start, unsigned long int end) {
 	char operand_s[100];
 
 	while (address < end) {
-		sprintf(line_buf, "%08x : ", address);
+		sprintf(line_buf, "%p : ", (void*)address);
 		print(0, line_buf);
 
 		const uint32_t start_address = address;
@@ -505,11 +505,11 @@ void disasm(unsigned long int start, unsigned long int end) {
 						int offset = (word & 0x00FF);
 						if (offset != 0) {
 							if (offset >= 128) offset -= 256;							
-							sprintf(operand_s, "$%08x", address + offset);							
+							sprintf(operand_s, "$%p", (void*)(address + offset));							
 						} else {
 							offset = getword();
 							if (offset >= 32768l) offset -= 65536l;
-							sprintf(operand_s, "$%08x" , address - 2 + offset);
+							sprintf(operand_s, "$%p" , (void*)(address - 2 + offset));
 						}
 						decoded = true;
 					} break;
@@ -652,7 +652,7 @@ void disasm(unsigned long int start, unsigned long int end) {
 						int offset = getword();
 						if (offset >= 32768) offset -= 65536;
 						const int dreg = word & 0x0007;
-						sprintf(operand_s, "D%i,$%08x", dreg, address - 2 + offset);
+						sprintf(operand_s, "D%d,$%p", dreg, (void*)(address - 2 + offset));
 						decoded = true;
 					} break;
 					case 33 : { /* EXG */
@@ -1094,7 +1094,7 @@ void disasm(unsigned long int start, unsigned long int end) {
 		//for (int i = 0 ; i < (5 - fetched); ++i) print(0,"     ");
 		
 		if (decoded != 0) {
-			sprintf(line_buf, "%-8s %s\n", opcode_s, operand_s)
+			sprintf(line_buf, "%-8s %s\n", opcode_s, operand_s);
 			print(0,line_buf);
 		} else {
 			print(0,"???\n");

--- a/src/cli/dos_cmds.c
+++ b/src/cli/dos_cmds.c
@@ -34,7 +34,7 @@ short cmd_diskread(short screen, int argc, char * argv[]) {
     bdev_number = (short)cli_eval_number(argv[1]);
     lba = cli_eval_number(argv[2]);
 
-    sprintf(buffer, "Reading drive #%d, sector 0x%X\n", bdev_number, lba);
+    sprintf(buffer, "Reading drive #%d, sector 0x%p\n", bdev_number, (void*)lba);
     print(screen, buffer);
 
     result = bdev_read(bdev_number, lba, buffer, 512);
@@ -70,7 +70,7 @@ short cmd_diskfill(short screen, int argc, char * argv[]) {
     lba = cli_eval_number(argv[2]);
     value = (unsigned char)cli_eval_number(argv[3]);
 
-    sprintf(buffer, "Filling drive #%d, sector 0x%X with 0x%02X\n", bdev_number, lba, value);
+    sprintf(buffer, "Filling drive #%d, sector %p with 0x%02X\n", bdev_number, (void*)lba, (short)value);
     print(screen, buffer);
 
     for (i = 0; i < 512; i++) {

--- a/src/cli/dos_cmds.c
+++ b/src/cli/dos_cmds.c
@@ -34,7 +34,7 @@ short cmd_diskread(short screen, int argc, const char * argv[]) {
     bdev_number = (short)cli_eval_number(argv[1]);
     lba = cli_eval_number(argv[2]);
 
-    sprintf(buffer, "Reading drive #%d, sector 0x%p\n", bdev_number, (void*)lba);
+    sprintf(buffer, "Reading drive #%d, sector %p\n", bdev_number, (void*)lba);
     print(screen, buffer);
 
     result = bdev_read(bdev_number, lba, buffer, 512);

--- a/src/cli/dos_cmds.c
+++ b/src/cli/dos_cmds.c
@@ -19,7 +19,7 @@
  *
  * DISKREAD <drive #> <sector #>
  */
-short cmd_diskread(short screen, int argc, char * argv[]) {
+short cmd_diskread(short screen, int argc, const char * argv[]) {
     unsigned char buffer[512];
     short bdev_number = 0;
     long lba = 0;
@@ -53,7 +53,7 @@ short cmd_diskread(short screen, int argc, char * argv[]) {
  *
  * DISKFILL <drive #> <sector #> <value>
  */
-short cmd_diskfill(short screen, int argc, char * argv[]) {
+short cmd_diskfill(short screen, int argc, const char * argv[]) {
     unsigned char buffer[512];
     unsigned char value;
     short bdev_number = 0;
@@ -93,7 +93,7 @@ short cmd_diskfill(short screen, int argc, char * argv[]) {
  *
  * Command name is in argv[0].
  */
-short cmd_run(short screen, int argc, char * argv[]) {
+short cmd_run(short screen, int argc, const char * argv[]) {
     TRACE("cmd_run");
 
     short result = proc_run(argv[0], argc, argv);
@@ -108,7 +108,7 @@ short cmd_run(short screen, int argc, char * argv[]) {
 /*
  * Create a directory
  */
-short cmd_mkdir(short screen, int argc, char * argv[]) {
+short cmd_mkdir(short screen, int argc, const char * argv[]) {
 
     TRACE("cmd_mkdir");
 
@@ -127,7 +127,7 @@ short cmd_mkdir(short screen, int argc, char * argv[]) {
 /*
  * Delete a file
  */
-short cmd_del(short screen, int argc, char * argv[]) {
+short cmd_del(short screen, int argc, const char * argv[]) {
 
     TRACE("cmd_del");
 
@@ -143,7 +143,7 @@ short cmd_del(short screen, int argc, char * argv[]) {
     }
 }
 
-short cmd_copy(short screen, int argc, char * argv[]) {
+short cmd_copy(short screen, int argc, const char * argv[]) {
     FRESULT find_result;
     FRESULT result;
     DIR dir;         /* Directory object */
@@ -228,7 +228,7 @@ error:
 /*
  * Change the directory
  */
-short cmd_cd(short screen, int argc, char * argv[]) {
+short cmd_cd(short screen, int argc, const char * argv[]) {
 
     TRACE("cmd_cd");
 
@@ -253,7 +253,7 @@ short cmd_cd(short screen, int argc, char * argv[]) {
 /*
  * Change the directory
  */
-short cmd_pwd(short screen, int argc, char * argv[]) {
+short cmd_pwd(short screen, int argc, const char * argv[]) {
     char buffer[128];
 
     TRACE("cmd_pwd");
@@ -271,7 +271,7 @@ short cmd_pwd(short screen, int argc, char * argv[]) {
 /*
  * Rename a file or directory
  */
-short cmd_rename(short screen, int argc, char * argv[]) {
+short cmd_rename(short screen, int argc, const char * argv[]) {
 
     TRACE("cmd_rename");
 
@@ -286,7 +286,7 @@ short cmd_rename(short screen, int argc, char * argv[]) {
     return 0;
 }
 
-short cmd_dir(short screen, int argc, char * argv[]) {
+short cmd_dir(short screen, int argc, const char * argv[]) {
     short result;
     char buffer[80];
     t_file_info my_file;
@@ -294,7 +294,7 @@ short cmd_dir(short screen, int argc, char * argv[]) {
     char label[40];
 
     if (argc > 1) {
-        path = argv[1];
+        path = (char*)(argv[1]);
     }
 
     short dir = fsys_opendir(path);
@@ -342,11 +342,11 @@ short cmd_dir(short screen, int argc, char * argv[]) {
 /*
  * Print the contents of a file to the screen
  */
-short cmd_type(short screen, int argc, char * argv[]) {
+short cmd_type(short screen, int argc, const char * argv[]) {
     if (argc > 1) {
         unsigned char buffer[128];
 
-        log3(LOG_INFO, "Attempting to type [", argv[1], "]");
+        log3(LOG_INFO, "Attempting to type [", (char*)(argv[1]), "]");
         short fd = fsys_open(argv[1], FA_READ);
         if (fd >= 0) {
             log_num(LOG_INFO, "File open: ", fd);
@@ -379,7 +379,7 @@ short cmd_type(short screen, int argc, char * argv[]) {
  * Load a binary file into memory
  * parameters: path [address]
  */
-short cmd_load(short screen, int argc, char * argv[]) {
+short cmd_load(short screen, int argc, const char * argv[]) {
     if (argc > 1) {
         long start = 0;
         long destination = 0;
@@ -413,7 +413,7 @@ short cmd_load(short screen, int argc, char * argv[]) {
  * LABEL <drive #> <label>
  *
  */
-short cmd_label(short screen, int argc, char * argv[]) {
+short cmd_label(short screen, int argc, const char * argv[]) {
     if (argc > 2) {
         short drive = cli_eval_number(argv[1]);
         short result = fsys_setlabel(drive, argv[2]);
@@ -433,7 +433,7 @@ short cmd_label(short screen, int argc, char * argv[]) {
  *
  * FORMAT <drive #>
  */
-short cmd_format(short screen, int argc, char * argv[]) {
+short cmd_format(short screen, int argc, const char * argv[]) {
     if (argc > 1) {
         short drive = cli_eval_number(argv[1]);
         short result = fsys_mkfs(drive, "");

--- a/src/cli/dos_cmds.h
+++ b/src/cli/dos_cmds.h
@@ -8,66 +8,66 @@
 /*
  * Execute a binary file
  */
-extern short cmd_run(short screen, int argc, char * argv[]);
+extern short cmd_run(short screen, int argc, const char * argv[]);
 
 /*
  * List the directory at the given path
  */
-extern short cmd_dir(short screen, int argc, char * argv[]);
+extern short cmd_dir(short screen, int argc, const char * argv[]);
 
 /*
  * Create a directory
  */
-extern short cmd_mkdir(short screen, int argc, char * argv[]);
+extern short cmd_mkdir(short screen, int argc, const char * argv[]);
 
 /*
  * Delete a file or directory
  */
-extern short cmd_del(short screen, int argc, char * argv[]);
+extern short cmd_del(short screen, int argc, const char * argv[]);
 
 /*
  * Copies file(s) to destination
  */
-extern short cmd_copy(short screen, int argc, char * argv[]);
+extern short cmd_copy(short screen, int argc, const char * argv[]);
 
 /*
  * Set the current working directory
  */
-extern short cmd_cd(short screen, int argc, char * argv[]);
+extern short cmd_cd(short screen, int argc, const char * argv[]);
 
 /*
  * Print the current working directory
  */
-extern short cmd_pwd(short screen, int argc, char * argv[]);
+extern short cmd_pwd(short screen, int argc, const char * argv[]);
 
 /*
  * Rename a file or directory
  */
-extern short cmd_rename(short screen, int argc, char * argv[]);
+extern short cmd_rename(short screen, int argc, const char * argv[]);
 
 /*
  * Print the contents of a file to the screen
  */
-extern short cmd_type(short screen, int argc, char * argv[]);
+extern short cmd_type(short screen, int argc, const char * argv[]);
 
 /*
  * Load a binary file into memory
  */
-extern short cmd_load(short screen, int argc, char * argv[]);
+extern short cmd_load(short screen, int argc, const char * argv[]);
 
 /*
  * Read a sector off a drive
  *
  * DISKREAD <drive #> <sector #>
  */
-extern short cmd_diskread(short screen, int argc, char * argv[]);
+extern short cmd_diskread(short screen, int argc, const char * argv[]);
 
 /*
  * Fill a sector of a drive with a byte value
  *
  * DISKFILL <drive #> <sector #> <value>
  */
-extern short cmd_diskfill(short screen, int argc, char * argv[]);
+extern short cmd_diskfill(short screen, int argc, const char * argv[]);
 
 /*
  * Set the label of a drive
@@ -75,13 +75,13 @@ extern short cmd_diskfill(short screen, int argc, char * argv[]);
  * LABEL <drive #> <label>
  *
  */
-extern short cmd_label(short screen, int argc, char * argv[]);
+extern short cmd_label(short screen, int argc, const char * argv[]);
 
 /*
  * Format a drive
  *
  * FORMAT <drive #>
  */
-extern short cmd_format(short screen, int argc, char * argv[]);
+extern short cmd_format(short screen, int argc, const char * argv[]);
 
 #endif

--- a/src/cli/mem_cmds.c
+++ b/src/cli/mem_cmds.c
@@ -14,7 +14,7 @@
  *
  * DUMP <address> [<count>]
  */
-short mem_cmd_dump(short channel, int argc, char * argv[]) {
+short mem_cmd_dump(short channel, int argc, const char * argv[]) {
     unsigned char * address = 0;
     long count = 16;
     long i;
@@ -38,7 +38,7 @@ short mem_cmd_dump(short channel, int argc, char * argv[]) {
     }
 }
 
-short mem_cmd_dasm(short channel, int argc, char * argv[]) {
+short mem_cmd_dasm(short channel, int argc, const char * argv[]) {
     unsigned long address = 0;
     long count = 1000;
     long i;
@@ -73,7 +73,7 @@ short mem_cmd_dasm(short channel, int argc, char * argv[]) {
  *
  * POKE8 <address> <value>
  */
-short mem_cmd_poke8(short channel, int argc, char * argv[]) {
+short mem_cmd_poke8(short channel, int argc, const char * argv[]) {
     TRACE("mem_cmd_poke8");
 
     if (argc == 3) {
@@ -93,7 +93,7 @@ short mem_cmd_poke8(short channel, int argc, char * argv[]) {
  *
  * PEEK8 <address>
  */
-short mem_cmd_peek8(short channel, int argc, char * argv[]) {
+short mem_cmd_peek8(short channel, int argc, const char * argv[]) {
 
     TRACE("mem_cmd_peek8");
 
@@ -114,7 +114,7 @@ short mem_cmd_peek8(short channel, int argc, char * argv[]) {
  *
  * POKE16 <address> <value>
  */
-short mem_cmd_poke16(short channel, int argc, char * argv[]) {
+short mem_cmd_poke16(short channel, int argc, const char * argv[]) {
     TRACE("mem_cmd_poke16");
 
     if (argc == 3) {
@@ -134,11 +134,11 @@ short mem_cmd_poke16(short channel, int argc, char * argv[]) {
  *
  * PEEK16 <address>
  */
-short mem_cmd_peek16(short channel, int argc, char * argv[]) {
+short mem_cmd_peek16(short channel, int argc, const char * argv[]) {
     TRACE("mem_cmd_peek16");
 
     if (argc == 2) {
-        unsigned short * address = (unsigned char *)cli_eval_number(argv[1]);
+        unsigned short * address = (unsigned short *)cli_eval_number(argv[1]);
         unsigned short c = *address;
         print_hex_16(channel, c);
 
@@ -154,7 +154,7 @@ short mem_cmd_peek16(short channel, int argc, char * argv[]) {
  *
  * POKE32 <address> <value>
  */
-short mem_cmd_poke32(short channel, int argc, char * argv[]) {
+short mem_cmd_poke32(short channel, int argc, const char * argv[]) {
     TRACE("mem_cmd_poke32");
 
     if (argc == 3) {
@@ -174,11 +174,11 @@ short mem_cmd_poke32(short channel, int argc, char * argv[]) {
  *
  * PEEK32 <address>
  */
-short mem_cmd_peek32(short channel, int argc, char * argv[]) {
+short mem_cmd_peek32(short channel, int argc, const char * argv[]) {
     TRACE("mem_cmd_peek32");
 
     if (argc == 2) {
-        unsigned long * address = (unsigned char *)cli_eval_number(argv[1]);
+        unsigned long * address = (unsigned long *)cli_eval_number(argv[1]);
         unsigned long c = *address;
         print_hex_32(channel, c);
 

--- a/src/cli/mem_cmds.h
+++ b/src/cli/mem_cmds.h
@@ -12,55 +12,55 @@
  *
  * DUMP <address> [<count>]
  */
-extern short mem_cmd_dump(short channel, int argc, char * argv[]);
+extern short mem_cmd_dump(short channel, int argc, const char * argv[]);
 
 /*
  * Print out the dissassembly of a block of memory
  *
  * DASM <address> [<count>]
  */
-extern short mem_cmd_dasm(short channel, int argc, char * argv[]);
+extern short mem_cmd_dasm(short channel, int argc, const char * argv[]);
 
 /*
  * Write an 8-bit byte to memory
  *
  * POKE8 <address> <value>
  */
-extern short mem_cmd_poke8(short channel, int argc, char * argv[]);
+extern short mem_cmd_poke8(short channel, int argc, const char * argv[]);
 
 /*
  * Read an 8-bit byte from memory and display it
  *
  * PEEK8 <address>
  */
-extern short mem_cmd_peek8(short channel, int argc, char * argv[]);
+extern short mem_cmd_peek8(short channel, int argc, const char * argv[]);
 
 /*
  * Write an 16-bit word to memory
  *
  * POKE16 <address> <value>
  */
-extern short mem_cmd_poke16(short channel, int argc, char * argv[]);
+extern short mem_cmd_poke16(short channel, int argc, const char * argv[]);
 
 /*
  * Read an 16-bit word from memory and display it
  *
  * PEEK16 <address>
  */
-extern short mem_cmd_peek16(short channel, int argc, char * argv[]);
+extern short mem_cmd_peek16(short channel, int argc, const char * argv[]);
 
 /*
  * Write an 32-bit long word to memory
  *
  * POKE32 <address> <value>
  */
-extern short mem_cmd_poke32(short channel, int argc, char * argv[]);
+extern short mem_cmd_poke32(short channel, int argc, const char * argv[]);
 
 /*
  * Read an 32-bit long word from memory and display it
  *
  * PEEK32 <address>
  */
-extern short mem_cmd_peek32(short channel, int argc, char * argv[]);
+extern short mem_cmd_peek32(short channel, int argc, const char * argv[]);
 
 #endif

--- a/src/cli/settings.c
+++ b/src/cli/settings.c
@@ -158,7 +158,7 @@ short cli_set_value(short channel, const char * name, const char * value) {
  * Returns:
  * 0 on success, any other number is an error
  */
-short cli_get_value(short channel, char * name, char * buffer, short size) {
+short cli_get_value(short channel, const char * name, char * buffer, short size) {
     p_setting setting = cli_find_setting(name);
     if (setting == 0) {
         /* Setting not found... */
@@ -214,7 +214,7 @@ short cli_cmd_set(short channel, int argc, const char * argv[]) {
 /*
  * Command to set the value of a setting
  */
-short cli_cmd_get(short channel, int argc, char * argv[]) {
+short cli_cmd_get(short channel, int argc, const char * argv[]) {
     char buffer[128];
     short result;
 
@@ -224,7 +224,7 @@ short cli_cmd_get(short channel, int argc, char * argv[]) {
             cli_set_help(channel);
 
         } else {
-            result = cli_get_value(channel, argv[1], buffer, 128);
+            result = cli_get_value(channel, (char*)argv[1], buffer, 128);
             if (result == 0) {
                 print(channel, buffer);
                 print(channel, "\n");

--- a/src/cli/settings.c
+++ b/src/cli/settings.c
@@ -6,8 +6,10 @@
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
+#include "cli.h"
 #include "log.h"
 #include "errors.h"
 #include "settings.h"
@@ -73,7 +75,8 @@ short cli_set_register(const char * name, const char * help, cli_setter setter, 
     } else {
         /* Set the fields for the setting */
         cli_name_upper(setting->name, name);
-        strncpy(setting->help, help);
+        strncpy(setting->help, help, MAX_SETTING_HELP);
+        setting->help[MAX_SETTING_HELP] = '\0';
         setting->setter = setter;
         setting->getter = getter;
         setting->next = 0;
@@ -155,7 +158,7 @@ short cli_set_value(short channel, const char * name, const char * value) {
  * Returns:
  * 0 on success, any other number is an error
  */
-short cli_get_value(short channel, const char * name, char * buffer, short size) {
+short cli_get_value(short channel, char * name, char * buffer, short size) {
     p_setting setting = cli_find_setting(name);
     if (setting == 0) {
         /* Setting not found... */
@@ -181,14 +184,12 @@ void cli_set_help(short channel) {
         sys_chan_write(channel, setting->help, strlen(setting->help));
         sys_chan_write(channel, "\n", 1);
     }
-
-    return 0;
 }
 
 /*
  * Command to set the value of a setting
  */
-short cli_cmd_set(short channel, int argc, char * argv[]) {
+short cli_cmd_set(short channel, int argc, const char * argv[]) {
     char message[80];
     short result;
 
@@ -201,7 +202,7 @@ short cli_cmd_set(short channel, int argc, char * argv[]) {
         }
         return result;
 
-    } else if ((argc == 2) && ((strcmp(argv[1], "HELP") == 0) || (strcmp(argv[1], "help") == 0) || (strcmp(argv[1], "?") == 0)) {
+    } else if ((argc == 2) && (strcmp(argv[1], "HELP") == 0 || strcmp(argv[1], "help") == 0 || strcmp(argv[1], "?") == 0)) {
         cli_set_help(channel);
 
     } else {
@@ -328,19 +329,19 @@ short cli_date_set(short channel, const char * date) {
         if ((i == 4) || (i == 7)) {
             if (date[i] != '-') {
                 sys_chan_write(channel, usage, strlen(usage));
-                return -1;
+                return ERR_GENERAL;
             }
         } else {
             if ((date[i] < '0') || (date[i] > '9')) {
                 sys_chan_write(channel, usage, strlen(usage));
-                return -1;
+                return ERR_GENERAL;
             }
         }
     }
 
-    date_time.year = atoi_n(&date[0], 4);
-    date_time.month = atoi_n(&date[5], 2);
-    date_time.day = atoi_n(&date[8], 2);
+    date_time.year = atoi_n(&((char*)date)[0], 4);
+    date_time.month = atoi_n(&((char*)date)[5], 2);
+    date_time.day = atoi_n(&((char*)date)[8], 2);
 
     rtc_set_time(&date_time);
 
@@ -350,7 +351,7 @@ short cli_date_set(short channel, const char * date) {
 /*
  * DATE getter
  */
-short cli_date_get(short channel, char * value) {
+short cli_date_get(short channel, char * value, short size) {
     t_time time;
 
     rtc_get_time(&time);
@@ -377,19 +378,19 @@ short cli_time_set(short channel, const char * time) {
         if ((i == 2) || (i == 5)) {
             if (time[i] != ':') {
                 sys_chan_write(channel, usage, strlen(usage));
-                return -1;
+                return ERR_GENERAL;
             }
         } else {
             if ((time[i] < '0') || (time[i] > '9')) {
                 sys_chan_write(channel, usage, strlen(usage));
-                return -1;
+                return ERR_GENERAL;
             }
         }
     }
 
-    date_time.hour = atoi_n(&time[0], 2);
-    date_time.minute = atoi_n(&time[3], 2);
-    date_time.second = atoi_n(&time[6], 2);
+    date_time.hour = atoi_n(&((char*)time)[0], 2);
+    date_time.minute = atoi_n(&((char*)time)[3], 2);
+    date_time.second = atoi_n(&((char*)time)[6], 2);
 
     rtc_set_time(&date_time);
 
@@ -399,7 +400,7 @@ short cli_time_set(short channel, const char * time) {
 /*
  * TIME getter
  */
-short cli_time_get(short channel, char * value) {
+short cli_time_get(short channel, char * value, short size) {
     t_time time;
 
     rtc_get_time(&time);
@@ -443,7 +444,7 @@ short cli_font_set(short screen, const char * value) {
 /*
  * Font setter -- GET FONT <path>
  */
-short cli_font_get(short channel, char * value) {
+short cli_font_get(short channel, char * value, short size) {
     /* We don't keep the font path */
     *value = 0;
     return 0;
@@ -452,7 +453,7 @@ short cli_font_get(short channel, char * value) {
 /*
  * Volume setter -- SET VOLUME <value>
  */
-short cli_volume_set(short channel, char * value) {
+short cli_volume_set(short channel, const char * value) {
     unsigned char volume = (unsigned char)cli_eval_number(value);
     codec_set_volume(volume);
     return 0;
@@ -461,8 +462,8 @@ short cli_volume_set(short channel, char * value) {
 /*
  * Volume getter -- GET VOLUME
  */
-short cli_volume_get(short channel, char * value) {
-    sprintf(value, "%d", codec_get_volume());
+short cli_volume_get(short channel, char * value, short size) {
+    sprintf(value, "%d", (short)codec_get_volume());
     return 0;
 }
 
@@ -494,7 +495,7 @@ short cli_layout_set(short channel, const char * value) {
 /*
  * Get the keyboard layout given a keyboard layout file -- GET LAYOUT
  */
-short cli_layout_get(short channel, char * value) {
+short cli_layout_get(short channel, char * value, short size) {
     return 0;
 }
 

--- a/src/cli/settings.h
+++ b/src/cli/settings.h
@@ -29,24 +29,26 @@ extern void cli_set_init();
  * Returns:
  * 0 on success, any other number is an error
  */
-extern short cli_set_register(const char * name, cli_setter setter, cli_getter getter);
+extern short cli_set_register(const char * name, const char * help, cli_setter setter, cli_getter getter);
 
 /*
  * Set the value of a setting
  *
  * Inputs:
+ * channel = the channel to use for reporting success or error
  * name = the name of the setting to update (case insensitive)
  * value = the value to store in the setting (may be interpreted by the setting)
  *
  * Returns:
  * 0 on success, any other number is an error
  */
-extern short cli_set_value(const char * name, const char * value);
+extern short cli_set_value(short channel, const char * name, const char * value);
 
 /*
  * Get the value of a setting
  *
  * Inputs:
+ * channel = the channel to use for reporting success or error
  * name = the name of the setting to update (case insensitive)
  * buffer = the place to copy a string representing the value of the setting
  * size = the number of characters that can be stored in the buffer
@@ -54,12 +56,12 @@ extern short cli_set_value(const char * name, const char * value);
  * Returns:
  * 0 on success, any other number is an error
  */
-extern short cli_get_value(const char * name, char * buffer, short size);
+extern short cli_get_value(short channel, char * name, char * buffer, short size);
 
 /*
  * Command to set the value of a setting
  */
-extern short cli_cmd_set(short screen, int argc, char * argv[]);
+extern short cli_cmd_set(short screen, int argc, const char * argv[]);
 
 /*
  * Command to set the value of a setting

--- a/src/cli/settings.h
+++ b/src/cli/settings.h
@@ -56,7 +56,7 @@ extern short cli_set_value(short channel, const char * name, const char * value)
  * Returns:
  * 0 on success, any other number is an error
  */
-extern short cli_get_value(short channel, char * name, char * buffer, short size);
+extern short cli_get_value(short channel, const char * name, char * buffer, short size);
 
 /*
  * Command to set the value of a setting
@@ -66,6 +66,6 @@ extern short cli_cmd_set(short screen, int argc, const char * argv[]);
 /*
  * Command to set the value of a setting
  */
-extern short cli_cmd_get(short screen, int argc, char * argv[]);
+extern short cli_cmd_get(short screen, int argc, const char * argv[]);
 
 #endif

--- a/src/cli/sound_cmds.c
+++ b/src/cli/sound_cmds.c
@@ -13,7 +13,7 @@
 /*
  * Play a sound on the PSG
  */
-short psg_test(short channel, int argc, char * argv[]) {
+short psg_test(short channel, int argc, const char * argv[]) {
     int i;
     long target_time;
 
@@ -94,7 +94,7 @@ const unsigned char opl3_tone_off[] = {
 /*
  * Play a sound on the OPL3
  */
-short opl3_test(short channel, int argc, char * argv[]) {
+short opl3_test(short channel, int argc, const char * argv[]) {
     short i;
     unsigned char reg;
     unsigned char data;
@@ -132,7 +132,7 @@ short opl3_test(short channel, int argc, char * argv[]) {
 /*
  * Perform a transmit test on the MIDI ports
  */
-short midi_tx_test(short channel, int argc, char * argv[]) {
+short midi_tx_test(short channel, int argc, const char * argv[]) {
 #if MODEL == MODEL_FOENIX_A2560K
     const char note_on[] = { 0x90, 0x3c, 0xff };
     const char note_off[] = { 0x80, 0x3c, 0x00 };
@@ -158,7 +158,7 @@ short midi_tx_test(short channel, int argc, char * argv[]) {
 /*
  * Perform a receive test on the MIDI ports
  */
-short midi_rx_test(short channel, int argc, char * argv[]) {
+short midi_rx_test(short channel, int argc, const char * argv[]) {
 #if MODEL == MODEL_FOENIX_A2560K
     char message[80];
     unsigned short scancode = 0;
@@ -198,7 +198,7 @@ short midi_rx_test(short channel, int argc, char * argv[]) {
 /*
  * Perform a loopback test on the MIDI ports
  */
-short midi_loop_test(short channel, int argc, char * argv[]) {
+short midi_loop_test(short channel, int argc, const char * argv[]) {
 #if MODEL == MODEL_FOENIX_A2560K
     char message[80];
     unsigned short scancode = 0;
@@ -242,7 +242,7 @@ short midi_loop_test(short channel, int argc, char * argv[]) {
 /*
  * Test the OPL2
  */
-short opl2_test(short channel, int argc, char * argv[]) {
+short opl2_test(short channel, int argc, const char * argv[]) {
     unsigned char i;
 
     OPN2_INT_BASE[OPN2_22_LFO] = 0;     /* LFO off */

--- a/src/cli/sound_cmds.c
+++ b/src/cli/sound_cmds.c
@@ -8,6 +8,7 @@
 #include "snd/psg.h"
 #include "snd/opl2.h"
 #include "dev/midi.h"
+#include "syscalls.h"
 
 /*
  * Play a sound on the PSG

--- a/src/cli/sound_cmds.h
+++ b/src/cli/sound_cmds.h
@@ -8,31 +8,31 @@
 /*
  * Play a sound on the PSG
  */
-extern short psg_test(short channel, int argc, char * argv[]);
+extern short psg_test(short channel, int argc, const char * argv[]);
 
 /*
  * Play a sound on the OPL3
  */
-extern short opl3_test(short channel, int argc, char * argv[]);
+extern short opl3_test(short channel, int argc, const char * argv[]);
 
 /*
  * Test the OPL2
  */
-extern short opl2_test(short channel, int argc, char * argv[]);
+extern short opl2_test(short channel, int argc, const char * argv[]);
 
 /*
  * Perform a transmit test on the MIDI ports
  */
-extern short midi_tx_test(short channel, int argc, char * argv[]);
+extern short midi_tx_test(short channel, int argc, const char * argv[]);
 
 /*
  * Perform a receive test on the MIDI ports
  */
-extern short midi_rx_test(short channel, int argc, char * argv[]);
+extern short midi_rx_test(short channel, int argc, const char * argv[]);
 
 /*
  * Perform a loopback test on the MIDI ports
  */
-extern short midi_loop_test(short channel, int argc, char * argv[]);
+extern short midi_loop_test(short channel, int argc, const char * argv[]);
 
 #endif

--- a/src/cli/test_cmd2.c
+++ b/src/cli/test_cmd2.c
@@ -59,7 +59,7 @@ typedef struct s_cli_test_feature {
  * Tests...
  */
 
-short cli_test_bitmap(short channel, int argc, char * argv[]) {
+short cli_test_bitmap(short channel, int argc, const char * argv[]) {
     int i,m,p;
     unsigned char j;
     unsigned short k;
@@ -83,7 +83,7 @@ short cli_test_bitmap(short channel, int argc, char * argv[]) {
     return 0;
 }
 
-short cli_test_uart(short channel, int argc, char * argv[]) {
+short cli_test_uart(short channel, int argc, const char * argv[]) {
     char c;
     char buffer[80];
 
@@ -110,7 +110,7 @@ short cli_test_uart(short channel, int argc, char * argv[]) {
     return 0;
 }
 
-short cli_test_panic(short channel, int argc, char * argv[]) {
+short cli_test_panic(short channel, int argc, const char * argv[]) {
     volatile int x = 0;
     return argc / x;
 }
@@ -118,7 +118,7 @@ short cli_test_panic(short channel, int argc, char * argv[]) {
 /*
  * Try using the RTC periodic interrupt in polled mode
  */
-short cli_test_rtc(short channel, int argc, char * argv[]) {
+short cli_test_rtc(short channel, int argc, const char * argv[]) {
     char buffer[80];
     char * spinner = "|/-\\";
     short count = 0;
@@ -150,7 +150,7 @@ short cli_test_rtc(short channel, int argc, char * argv[]) {
 /*
  * Test the memory
  */
-short cli_mem_test(short channel, int argc, char * argv[]) {
+short cli_mem_test(short channel, int argc, const char * argv[]) {
     volatile unsigned char * memory = 0x00000000;
     t_sys_info sys_info;
     const long mem_start = 0x00050000;
@@ -201,7 +201,7 @@ short cli_mem_test(short channel, int argc, char * argv[]) {
 /*
  * Test the IDE interface by reading the MBR
  */
-short cli_test_ide(short screen, int argc, char * argv[]) {
+short cli_test_ide(short screen, int argc, const char * argv[]) {
     unsigned char buffer[512];
     short i;
     short scancode;
@@ -230,7 +230,7 @@ short cli_test_ide(short screen, int argc, char * argv[]) {
 /*
  * Test file creation
  */
-short cli_test_create(short screen, int argc, char * argv[]) {
+short cli_test_create(short screen, int argc, const char * argv[]) {
     short n;
 
     if (argc > 1) {
@@ -256,7 +256,7 @@ short cli_test_create(short screen, int argc, char * argv[]) {
     }
 }
 
-short cli_test_lpt(short screen, int argc, char * argv[]) {
+short cli_test_lpt(short screen, int argc, const char * argv[]) {
 #if MODEL == MODEL_FOENIX_A2560K
     char message[80];
     unsigned char scancode;
@@ -312,7 +312,7 @@ short cli_test_lpt(short screen, int argc, char * argv[]) {
     return 0;
 }
 
-short cmd_test_print(short screen, int argc, char * argv[]) {
+short cmd_test_print(short screen, int argc, const char * argv[]) {
 #if MODEL == MODEL_FOENIX_A2560K
     const char * test_pattern = "0123456789ABCDEFGHIJKLMNOPQRTSUVWZXYZ\r\n";
 
@@ -372,7 +372,7 @@ void test_help(short screen) {
 /*
  * Test command
  */
-short cmd_test(short screen, int argc, char * argv[]) {
+short cmd_test(short screen, int argc, const char * argv[]) {
     short i;
     p_cli_test_feature f;
 

--- a/src/cli/test_cmd2.c
+++ b/src/cli/test_cmd2.c
@@ -153,7 +153,7 @@ short cli_test_rtc(short channel, int argc, const char * argv[]) {
 short cli_mem_test(short channel, int argc, const char * argv[]) {
     volatile unsigned char * memory = 0x00000000;
     t_sys_info sys_info;
-    const long mem_start = 0x00050000;
+    const long mem_start = 0x00050000; /* TODO find out better where the kernel stop */
     long mem_end;
     char message[80];
     long i;
@@ -165,14 +165,14 @@ short cli_mem_test(short channel, int argc, const char * argv[]) {
     sys_chan_write(channel, message, strlen(message));
 
     for (i = mem_start; i < mem_end; i++) {
-        memory[i] = 0x55;
+        memory[i] = 0x55; /* Every other bit starting with 1 */
         if (memory[i] != 0x55) {
             sprintf(message, "\x1B[1;2H\x1B[KFailed to write 0x55... read %02X at %p\n\n", memory[i], (void*)i);
             sys_chan_write(channel, message, strlen(message));
             return ERR_GENERAL;
         }
 
-        memory[i] = 0xAA;
+        memory[i] = 0xAA; /* Every other bit starting with 0 */
         if (memory[i] != 0xAA) {
             sprintf(message, "\x1B[1;2H\x1B[KFailed to write 0xAA... read %02X at %p\n\n", memory[i], (void*)i);
             sys_chan_write(channel, message, strlen(message));

--- a/src/cli/test_cmds.h
+++ b/src/cli/test_cmds.h
@@ -8,6 +8,6 @@
 /*
  * Test command
  */
-extern short cmd_test(short channel, int argc, char * argv[]);
+extern short cmd_test(short channel, int argc, const char * argv[]);
 
 #endif

--- a/src/dev/fsys.c
+++ b/src/dev/fsys.c
@@ -7,7 +7,9 @@
  */
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
+
 #include <string.h>
 #include "log.h"
 #include "syscalls.h"
@@ -731,7 +733,7 @@ short fsys_getlabel(char * path, char * label) {
  * drive = drive number
  * label = buffer that holds the label
  */
-short fsys_setlabel(short drive, char * label) {
+short fsys_setlabel(short drive, const char * label) {
     FRESULT fres;
     char buffer[80];
 

--- a/src/dev/fsys.c
+++ b/src/dev/fsys.c
@@ -375,7 +375,6 @@ short fsys_mkdir(const char * path) {
 
     result = f_mkdir(path);
     if (result == FR_OK) {
-        log_num(LOG_ERROR, "fsys_mkdir error: ", result);
         return 0;
     } else {
         log_num(LOG_ERROR, "fsys_mkdir error: ", result);

--- a/src/dev/fsys.h
+++ b/src/dev/fsys.h
@@ -141,7 +141,7 @@ extern short fsys_getlabel(char * path, char * label);
  * drive = drive number
  * label = buffer that holds the label
  */
-extern short fsys_setlabel(short drive, char * label);
+extern short fsys_setlabel(short drive, const char * label);
 
 /*
  * Format a drive

--- a/src/dev/text_screen_iii.c
+++ b/src/dev/text_screen_iii.c
@@ -89,6 +89,7 @@ int text_init() {
 #endif
 
     for (i = 0; i < MAX_TEXT_CHANNELS; i++) {
+        #pragma dontwarn 113 // only 0 should be assigned to pointer
         text_channel[i].master_control = 0xffffffff;
         text_channel[i].text_cells = 0xffffffff;
         text_channel[i].color_cells = 0xffffffff;
@@ -97,6 +98,7 @@ int text_init() {
         text_channel[i].border_control = 0xffffffff;
         text_channel[i].text_cursor_ptr = 0xffffffff;
         text_channel[i].color_cursor_ptr = 0xffffffff;
+        #pragma popwarn
         text_channel[i].current_color = 0;
         text_channel[i].columns_max = 0;
         text_channel[i].rows_max = 0;
@@ -539,10 +541,10 @@ void text_scroll(short screen) {
         for (row = 0; row < chan->rows_visible - 1; row++) {
             short offset1 = row * chan->columns_max;
             short offset2 = (row + 1) * chan->columns_max;
-            volatile short * text_dest = &chan->text_cells[offset1];
-            volatile short * color_dest = &chan->color_cells[offset1];
-            volatile short * text_src = &chan->text_cells[offset2];
-            volatile short * color_src = &chan->color_cells[offset2];
+            volatile short * text_dest = (short*)&chan->text_cells[offset1];
+            volatile short * color_dest = (short*)&chan->color_cells[offset1];
+            volatile short * text_src = (short*)&chan->text_cells[offset2];
+            volatile short * color_src = (short*)&chan->color_cells[offset2];
 
             for (column = 0; column < chan->columns_max; column += 2) {
                 *text_dest++ = *text_src++;
@@ -551,8 +553,8 @@ void text_scroll(short screen) {
         }
 
         short offset3 = (chan->rows_visible - 1) * chan->columns_max;
-        volatile short * text_dest = &chan->text_cells[offset3];
-        volatile short * color_dest = &chan->color_cells[offset3];
+        volatile short * text_dest = (short*)&chan->text_cells[offset3];
+        volatile short * color_dest = (short*)&chan->color_cells[offset3];
         uint8_t color = chan->current_color;
         for (column = 0; column < chan->columns_max; column += 2) {
             *text_dest++ = ' ';

--- a/src/dev/text_screen_iii.h
+++ b/src/dev/text_screen_iii.h
@@ -115,7 +115,7 @@ extern void text_clear(short screen, short mode);
  *        1: erase from cursor to end of the line,
  *        2: erase entire line
  */
-extern text_clear_line(short screen, short mode);
+extern void text_clear_line(short screen, short mode);
 
 /*
  * Insert a number of characters at the cursor position

--- a/src/include/syscalls.h
+++ b/src/include/syscalls.h
@@ -245,7 +245,7 @@ extern short sys_chan_write_b(short channel, unsigned char b);
  * Returns:
  *  number of bytes written, any negative number is an error code
  */
-extern short sys_chan_write(short channel, unsigned char * buffer, short size);
+extern short sys_chan_write(short channel, const unsigned char * buffer, short size);
 
 /*
  * Return the status of the channel device

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -6,6 +6,7 @@
 #define __TYPES_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * Function types
@@ -15,7 +16,6 @@
  * Integer types in their standard sizes, signed and unsigned.
  */
 
-typedef unsigned char bool;
 
 //
 // A color (BGR)

--- a/src/log.c
+++ b/src/log.c
@@ -2,7 +2,10 @@
  * A logging utility
  */
 
+#include <stdio.h>
 #include <string.h>
+
+#include "interrupt.h"
 #include "log.h"
 #include "simpleio.h"
 #include "dev/text_screen_iii.h"
@@ -242,7 +245,7 @@ void log2(short level, char * message1, char * message2) {
  * message2 = the second part of the message to log
  * message3 = the third part of the message to log
  */
-void log3(short level, char * message1, char * message2, char * message3) {
+void log3(short level, const char * message1, const char * message2, const char * message3) {
     if (level <= log_level) {
         print(log_channel, message1);
         print(log_channel, message2);

--- a/src/log.h
+++ b/src/log.h
@@ -72,7 +72,7 @@ extern void log2(short level, char * message1, char * message2);
  * message2 = the second part of the message to log
  * message3 = the third part of the message to log
  */
-extern void log3(short level, char * message1, char * message2, char * message3);
+extern void log3(short level, const char * message1, const char * message2, const char * message3);
 
 /*
  * Log a message with a number

--- a/src/simpleio.c
+++ b/src/simpleio.c
@@ -25,10 +25,12 @@ void print_c(short channel, char c) {
  * channel = the number of the channel
  * message = the ASCII-Z string to print
  */
-void print(short channel, char * message) {
-    int i;
-    for (i = 0; i < strlen(message); i++) {
-        print_c(channel, message[i]);
+void print(short channel, const char * message) {
+    char *p = (char*)message;
+    char c;
+
+    while ((c = *p++)) {
+        print_c(channel, c);
     }
     // sys_chan_write(channel, message, strlen(message));
 }
@@ -158,7 +160,7 @@ unsigned char i_to_bcd(unsigned short n) {
  * size = the number of bytes to print
  * labels = 0: none, 1: offset, 2: address
  */
-void dump_buffer(short channel, unsigned char * buffer, short size, short labels) {
+void dump_buffer(short channel, const unsigned char * buffer, short size, short labels) {
     short i, j, ascii_idx;
     char ascii_buffer[17];
     unsigned char c;

--- a/src/simpleio.h
+++ b/src/simpleio.h
@@ -12,7 +12,7 @@
  * channel = the number of the channel
  * message = the ASCII-Z string to print
  */
-extern void print(short channel, char * message);
+extern void print(short channel, const char * message);
 
 /*
  * Print a character to a channel
@@ -81,6 +81,6 @@ extern unsigned char i_to_bcd(unsigned short n);
  * size = the number of bytes to print
  * labels = 0: none, 1: offset, 2: address
  */
-extern void dump_buffer(short channel, unsigned char * buffer, short size, short labels);
+extern void dump_buffer(short channel, const unsigned char * buffer, short size, short labels);
 
 #endif

--- a/src/snd/codec.c
+++ b/src/snd/codec.c
@@ -4,7 +4,7 @@
 
 #include "snd/codec.h"
 
-static unsigned byte volume = 0xff;
+static unsigned char volume = 0xff;
 
 /*
  * Wait for the CODEC to be ready to receive more data.
@@ -41,10 +41,10 @@ void init_codec() {
 void codec_set_volume(unsigned char vol) {
     volume = vol;
 
-    *CODEC = 0x0A00 | (0xFF - (vol & 0xFF));
+    *CODEC = 0x0A00 | (0xFF - vol);
     codec_wait();
 
-	*CODEC = 0x0400 | ((vol >> 1) & 0xff);
+	*CODEC = 0x0400 | (vol >> 1);
     codec_wait();
 }
 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -175,7 +175,7 @@ short sys_chan_write_b(short channel, unsigned char b) {
  * Returns:
  *  number of bytes written, any negative number is an error code
  */
-short sys_chan_write(short channel, unsigned char * buffer, short size) {
+short sys_chan_write(short channel, const unsigned char * buffer, short size) {
     return syscall(KFN_CHAN_WRITE, channel, buffer, size);
 }
 


### PR DESCRIPTION
I did "make clean;make" then worked from the bottom.
The intent is that ultimately everything should compile clean without warning. I think I addressed about 50% of warnings. The rest should be no problem. Common problems are:
* Types used in the printf format strings are not consistent with the parameters.
* Inconsistent fonction prototypes 
* Missing casts

In codec.c there was a `unsigned byte volume` with `byte` not being defined and defaulting to `int`. I changed that to `unsigned char`  so could remove the `& 0xff`.

The internal "programs" `(called with short argc, char *argv)` I made `argv` as `const` because I think it's safe, and it allows the compiler to make optimizations.

**This is a draft PR**, I created it for info of others and so they see how to resolve warnings.
I need to test it these changes because I wrote it from my couch near the stove rather than in my "workshop" :)

Note to self: see if %p is rendered correctly (as 0xaaaaaaaa) and I might have a few places where it's 0x%p rather than just 0x.  