### PR TITLE
Automatic Binary Extension lookup for A2560K

### DIFF
--- a/src/dev/fsys.c
+++ b/src/dev/fsys.c
@@ -1177,50 +1177,43 @@ short fsys_pgx_loader(short chan, long destination, long * start) {
     return result;
 }
 
-/*
- * Load a file into memory at the designated destination address.
- *
- * If destination = 0, the file must be in a recognized binary format
- * that specifies its own loading address.
- *
- * Inputs:
- * path = the path to the file to load
- * destination = the destination address (0 for use file's address)
- * start = pointer to the long variable to fill with the starting address
- *         (0 if not an executable, any other number if file is executable
- *         with a known starting address)
- *
- * Returns:
- * 0 on success, negative number on error
- */
-short fsys_load(const char * path, long destination, long * start) {
+static bool loader_exists(const char * extension) {
     int i;
-    char extension[MAX_EXT];
+    for (i = 0; i < MAX_LOADERS; i++) {
+        if (g_file_loader[i].status) {
+            if (strcmp(g_file_loader[i].extension, extension) == 0) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static int get_app_ext(const char * path, char * extension) {
+    char * point = strrchr(path, '.');
+    extension[0] = 0;
+    if (point != 0) {
+        point++;
+        for (int i = 0; i < MAX_EXT; i++) {
+            char c = *point++;
+            if (c) {
+                extension[i] = toupper(c);
+            } else {
+                extension[i] = 0;
+                return 1;
+            }
+        }
+    } else {
+        return 0;
+    }
+}
+
+static short fsys_load_ext(const char * path, const char * extension, long destination, long * start) {
+    int i;
     short chan = -1;
     p_file_loader loader = 0;
 
     TRACE("fsys_load");
-
-    /* Clear out the extension */
-    for (i = 0; i <= MAX_EXT; i++) {
-        extension[i] = 0;
-    }
-
-    if (destination == 0) {
-        /* Find the extension */
-        char * point = strrchr(path, '.');
-        if (point != 0) {
-            point++;
-            for (i = 0; i < MAX_EXT; i++) {
-                char c = *point++;
-                if (c) {
-                    extension[i] = toupper(c);
-                } else {
-                    break;
-                }
-            }
-        }
-    }
 
     log2(LOG_VERBOSE, "fsys_load ext: ", extension);
 
@@ -1284,6 +1277,77 @@ short fsys_load(const char * path, long destination, long * start) {
         log_num(LOG_ERROR, "Could not open file: ", chan);
         return chan;
     }
+}
+
+
+/*
+ * Load a file into memory at the designated destination address.
+ *
+ * If destination = 0, the file must be in a recognized binary format
+ * that specifies its own loading address.
+ *
+ * Inputs:
+ * path = the path to the file to load
+ * destination = the destination address (0 for use file's address)
+ * start = pointer to the long variable to fill with the starting address
+ *         (0 if not an executable, any other number if file is executable
+ *         with a known starting address)
+ *
+ * Returns:
+ * 0 on success, negative number on error
+ */
+short fsys_load(const char * path, long destination, long * start) {
+    int i;
+    char extension[MAX_EXT];
+    char spath[MAX_PATH_LEN];
+    short chan = -1;
+    p_file_loader loader = 0;
+    int found_extension = 0;
+    int found_loader = 0;
+
+    FRESULT fr;     /* Return value */
+    DIR dj;         /* Directory object */
+    FILINFO fno;    /* File information */
+
+    TRACE("fsys_load");
+
+    /* Clear out the extension */
+    for (i = 0; i <= MAX_EXT; i++) {
+        extension[i] = 0;
+    }
+
+    found_extension = get_app_ext(path, extension);
+
+    if (found_extension || destination != 0) {
+        // extension provided, pass to loader
+        fsys_load_ext(path, extension, destination, start);
+    } else {
+        // extension not provided, search for a matching file.
+        strcpy(spath, path);
+        strcat(spath, ".*");
+
+        // TODO: Iterate through path, and replace "".
+        fr = f_findfirst(&dj, &fno, "", spath);       /* Start to search for executables */        
+        while (fr == FR_OK && fno.fname[0]) {         /* Repeat while an item is found */
+            get_app_ext(fno.fname, extension);
+            if (loader_exists(extension)) {
+                strcpy(spath, fno.fname);
+                found_loader = 1;
+                break;
+            }
+            fr = f_findnext(&dj, &fno);               /* Search for next item */
+        }
+        f_closedir(&dj);
+
+        if(found_loader) {
+            // Found path with valid loader
+            fsys_load_ext(spath, extension, destination, start);
+        } else {
+            log(LOG_ERROR, "Command not found.");
+            return chan;
+        }
+    }
+    return 0;
 }
 
 /*


### PR DESCRIPTION
I ported the missing Automatic Binary Extension lookup from main to a2560k

This allows you to type commands without extensions (i.e. `basic` instead of `basic.pgz`)